### PR TITLE
fix .local templating

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,7 +26,7 @@ nginx_reverse_proxy_upstream_host: localhost
 nginx_reverse_proxy_upstream_port: 8080
 nginx_reverse_proxy_upstream_header_host: "{{ nginx_reverse_proxy_site_name }}"
 nginx_reverse_proxy_config_name: "{{nginx_reverse_proxy_site_name}}-rproxy"
-nginx_reverse_proxy_server_name: "{{ nginx_reverse_proxy_site_name ~ local_test_environment|default('') }}"
+nginx_reverse_proxy_server_name: "{{ nginx_reverse_proxy_site_name }}"
 nginx_reverse_proxy_www_name: yes
 nginx_reverse_proxy_pass: http://{{ nginx_reverse_proxy_upstream_host }}:{{ nginx_reverse_proxy_upstream_port }}
 nginx_reverse_proxy_location_expressions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,34 +8,45 @@
 
 - name: Install reverse proxy and static file server site config.
   template:
-    src=nginx_reverse_proxy.j2
-    dest=/etc/nginx/sites-available/{{ nginx_reverse_proxy_config_name }}
-    owner=root
-    group=root
-    mode=0644
+    src: nginx_reverse_proxy.j2
+    dest: "/etc/nginx/sites-available/{{ nginx_reverse_proxy_config_name }}"
+    owner: root
+    group: root
+    mode: 0644
   notify: restart nginx
 
 - name: Create nginx config fragment dir.
   file:
-    state=directory
-    path=/etc/nginx/conf.d
-    owner=root group=root
-    mode=0775
+    state: directory
+    path: /etc/nginx/conf.d
+    owner: root
+    group: root
+    mode: 0775
   notify: restart nginx
 
 - name: Install proxy_cache default configuration.
   template:
-    src=proxy_cache_options.j2
-    dest=/etc/nginx/conf.d/100_proxy_cache_options.conf
-    owner=root
-    group=root
-    mode=0644
+    src: proxy_cache_options.j2
+    dest: /etc/nginx/conf.d/100_proxy_cache_options.conf
+    owner: root
+    group: root
+    mode: 0644
   notify: restart nginx
 
 - name: Enable Drupal reverse proxy and static file server
-  file: state=link src=/etc/nginx/sites-available/{{ nginx_reverse_proxy_config_name }} dest=/etc/nginx/sites-enabled/{{ nginx_reverse_proxy_config_name }} owner=root group=root
+  file:
+    state: link
+    src: "/etc/nginx/sites-available/{{ nginx_reverse_proxy_config_name }}"
+    dest: "/etc/nginx/sites-enabled/{{ nginx_reverse_proxy_config_name }}"
+    owner: root
+    group: root
   notify: restart nginx
 
 - name: Create nginx cache dir
-  file: state=directory path=/var/spool/nginx/cache owner=www-data group=root mode=775
+  file:
+    state: directory
+    path: /var/spool/nginx/cache
+    owner: www-data
+    group: root
+    mode: 775
   notify: restart nginx

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,5 +48,5 @@
     path: /var/spool/nginx/cache
     owner: www-data
     group: root
-    mode: 775
+    mode: 0775
   notify: restart nginx

--- a/templates/nginx_reverse_proxy.j2
+++ b/templates/nginx_reverse_proxy.j2
@@ -1,18 +1,27 @@
+# {{ ansible_managed }}
+{# Add local_test_enviroment top level domain to domain string in local testing. #}
+{% macro add_local(domain) -%}
+    {{domain}}{{local_test_environment|default('')}}
+{%- endmacro %}
+
 server {
-    {% for definition in nginx_listen %}listen {{definition}};
-    {% endfor %}
+{% for definition in nginx_listen %}
+    listen {{definition}};
+{% endfor %}
 
 {% if nginx_reverse_proxy_ssl == True %}
     ssl_certificate {{ ssl_certificate_certificate_dir }}/{{ ssl_certificate_chained }};
     ssl_certificate_key {{ ssl_certificate_key_dir }}/{{ ssl_certificate_key }};
 {% endif %}
 
-    server_name {{ nginx_reverse_proxy_server_name }}{% if nginx_reverse_proxy_www_name %} {{ 'www.' ~ nginx_reverse_proxy_server_name }}{% endif %};
+    server_name {{ add_local(nginx_reverse_proxy_server_name) }}{% if nginx_reverse_proxy_www_name %} {{ add_local('www.' ~ nginx_reverse_proxy_server_name) }}{% endif %};
+
 {% if nginx_reverse_proxy_alternate_site_names is defined %}
 {% for name in nginx_reverse_proxy_alternate_site_names %}
-    server_name {{ name ~ local_test_environment|default('') }}{% if nginx_reverse_proxy_www_name %} {{ 'www.' ~ name ~ local_test_environment|default('') }}{% endif %};
+    server_name {{ add_local(name) }}{% if nginx_reverse_proxy_www_name %} {{ add_local('www.' ~ name) }}{% endif %};
 {% endfor %}
 {% endif %}
+
 {% if nginx_reverse_proxy_root == True %}
     root {{ nginx_reverse_proxy_root_path }};
 
@@ -20,20 +29,20 @@ server {
         try_files $uri @proxy;
     }
 
-
-location ~ /files/styles/ {
- # expires 2h;
- try_files $uri @proxy;
- }
+    location ~ /files/styles/ {
+        # expires 2h;
+        try_files $uri @proxy;
+    }
 {% endif %}
 
 {% if site_specific is defined %}
 {{site_specific}}
 {% endif %}
-{%
-if nginx_reverse_proxy_upstream_host != 'localhost' %}
-{% set nginx_reverse_proxy_upstream_host = nginx_reverse_proxy_upstream_host ~ local_test_environment|default('') %}
+
+{% if nginx_reverse_proxy_upstream_host != 'localhost' %}
+{% set nginx_reverse_proxy_upstream_host = add_local(nginx_reverse_proxy_upstream_host) %}
 {% endif %}
+
 # Everything that needs to pass without caching goes through this.
     location @proxy {
        proxy_set_header Host {{ nginx_reverse_proxy_upstream_header_host }};


### PR DESCRIPTION
Move local testing domain '.local' handling from defaults to template.
This fixes missining .local when default value is not used.