### PR TITLE
Force creation of symlink

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,7 @@
     dest: "/etc/nginx/sites-enabled/{{ nginx_reverse_proxy_config_name }}"
     owner: root
     group: root
+    force: yes
   notify: restart nginx
 
 - name: Create nginx cache dir


### PR DESCRIPTION
Allows for creation of symlink even if the current configuration does
not yet exist (yet).

This is done because the "Enable Drupal reverse proxy..." task would
fail in checkmode.

For more information about the 'force' option see:
https://docs.ansible.com/ansible/latest/modules/file_module.html